### PR TITLE
fix: use terminfo for Home/End/Delete keybindings

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -108,11 +108,15 @@ source "$ZSH/oh-my-zsh.sh"
 
 # === Custom Config ===
 
-# --- Keybindings (safety net — oh-my-zsh may already set these) ---
+# --- Keybindings (safety net — oh-my-zsh sets most of these) ---
+# modifier+arrow: oh-my-zsh binds ctrl but not alt
 bindkey '^[[1;5C' forward-word       # ctrl+right
 bindkey '^[[1;5D' backward-word      # ctrl+left
 bindkey '^[[1;3C' forward-word       # alt+right
 bindkey '^[[1;3D' backward-word      # alt+left
+# standard keys: terminfo values (sequences vary by terminal type)
+[[ -n "${terminfo[khome]}" ]] && bindkey "${terminfo[khome]}" beginning-of-line
+[[ -n "${terminfo[kend]}"  ]] && bindkey "${terminfo[kend]}"  end-of-line
 
 # --- Prompt (Powerlevel10k) ---
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.

--- a/.zshrc.server
+++ b/.zshrc.server
@@ -17,25 +17,31 @@ zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"
 setopt COMPLETE_ALIASES
 
 # --- Keybindings ---
+# modifier+arrow: hardcoded xterm sequences (standard across all major frameworks)
 bindkey '^[[1;5C' forward-word       # ctrl+right
 bindkey '^[[1;5D' backward-word      # ctrl+left
 bindkey '^[[1;3C' forward-word       # alt+right
 bindkey '^[[1;3D' backward-word      # alt+left
-bindkey '^[[H'    beginning-of-line  # home
-bindkey '^[[F'    end-of-line        # end
-bindkey '^[[3~'   delete-char        # delete
+
+# standard keys: use terminfo (sequences differ between terminal types)
+[[ -n "${terminfo[khome]}" ]] && bindkey "${terminfo[khome]}" beginning-of-line  # home
+[[ -n "${terminfo[kend]}"  ]] && bindkey "${terminfo[kend]}"  end-of-line        # end
+[[ -n "${terminfo[kdch1]}" ]] && bindkey "${terminfo[kdch1]}" delete-char        # delete
+
+# application mode: required for terminfo values to match actual sequences
+# also handles tmux DA/OSC response leak workaround (tmux/tmux#4634)
+zle-line-init() {
+  (( ${+terminfo[smkx]} )) && echoti smkx
+  [[ -n "$TMUX" ]] && while read -t 0.01 -s -k 1 2>/dev/null; do :; done
+}
+zle-line-finish() {
+  (( ${+terminfo[rmkx]} )) && echoti rmkx
+}
+zle -N zle-line-init
+zle -N zle-line-finish
 
 # --- Prompt ---
 command -v starship &>/dev/null && eval "$(starship init zsh)" || PROMPT='%n@%m:%~$ '
-
-# workaround: tmux leaks DA/OSC responses on client attach (tmux/tmux#4634)
-# drain any leaked bytes from the input buffer before each prompt line
-if [[ -n "$TMUX" ]]; then
-  __drain_leaked_responses() {
-    while read -t 0.01 -s -k 1 2>/dev/null; do :; done
-  }
-  zle -N zle-line-init __drain_leaked_responses
-fi
 
 # --- Plugins (if available) ---
 [ -s ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh ] && source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh


### PR DESCRIPTION
## Summary

- Replace hardcoded escape sequences (`^[[H`, `^[[F`, `^[[3~`) with `terminfo` lookups (`khome`, `kend`, `kdch1`) for portable Home/End/Delete key bindings
- Enable application mode (`smkx`/`rmkx`) in `.zshrc.server` so terminfo values match actual terminal sequences
- Consolidate the tmux DA/OSC response drain workaround (tmux/tmux#4634) into `zle-line-init` alongside `smkx`

## Why

Hardcoded xterm sequences break on non-xterm terminals (e.g., `screen-256color` inside tmux). Using `terminfo` makes keybindings work regardless of `$TERM`.

## Test plan

- [ ] Verify Home/End/Delete keys work in plain zsh (no tmux)
- [ ] Verify Home/End/Delete keys work inside tmux (`screen-256color`)
- [ ] Verify ctrl+arrow and alt+arrow word navigation still works
- [ ] Verify no garbled input on tmux client attach (OSC drain)
- [ ] Test `.zshrc` (oh-my-zsh desktop) and `.zshrc.server` (minimal server) independently

## Code review

Reviewed — no CRITICAL or HIGH issues. 4 LOW findings (documentation nits, pre-existing timeout value). See review below.

<details>
<summary>Review findings (all LOW)</summary>

| Severity | File | Line | Issue |
|----------|------|------|-------|
| LOW | `.zshrc` | 118-119 | Missing `kdch1` (Delete) binding — `.zshrc.server` has it. Intentional: oh-my-zsh handles Delete. |
| LOW | `.zshrc` | 118-119 | No `smkx`/`rmkx` setup — relies on oh-my-zsh for application mode (undocumented dependency). |
| LOW | `.zshrc.server` | 33-41 | `zle -N zle-line-init` overwrites prior hook definitions. Fine for minimal server config. |
| LOW | `.zshrc.server` | 35 | 10ms drain timeout unchanged from before — works for local/low-latency SSH. |

</details>