### PR TITLE
add fzf ctrl-t/alt-c to server config, document gitconfig skip

### DIFF
--- a/.zshrc.server
+++ b/.zshrc.server
@@ -56,9 +56,14 @@ if [ -d /usr/share/doc/fzf/examples ]; then
   source /usr/share/doc/fzf/examples/completion.zsh 2>/dev/null
 fi
 if command -v fdfind &>/dev/null; then
-  export FZF_DEFAULT_COMMAND='fdfind --type f --hidden --follow --exclude .git'
+  FD_CMD="fdfind"
 elif command -v fd &>/dev/null; then
-  export FZF_DEFAULT_COMMAND='fd --type f --hidden --follow --exclude .git'
+  FD_CMD="fd"
+fi
+if [ -n "$FD_CMD" ]; then
+  export FZF_DEFAULT_COMMAND="$FD_CMD --type f --hidden --follow --exclude .git"
+  export FZF_CTRL_T_COMMAND="$FD_CMD --type f --hidden --follow --exclude .git"
+  export FZF_ALT_C_COMMAND="$FD_CMD --type d --hidden --follow --exclude .git"
 fi
 export FZF_DEFAULT_OPTS='--height 40% --layout=reverse --border'
 

--- a/install.sh
+++ b/install.sh
@@ -49,6 +49,13 @@ link "$DOTFILES/.tmux/scripts/status.sh" "$HOME/.tmux/scripts/status.sh"
 [ -d "$HOME/.tmux/plugins/tpm" ] || \
   git clone -q https://github.com/tmux-plugins/tpm "$HOME/.tmux/plugins/tpm"
 
+# --- Git ---
+# .gitconfig is NOT symlinked intentionally — it has portability issues:
+#   - hardcoded /usr/bin/gh path (fails if gh is missing or elsewhere)
+#   - delta pager (breaks git diff/log/show if delta is not installed)
+#   - LFS required=true (blocks clone/checkout without git-lfs)
+# Plan: split into base .gitconfig + ~/.gitconfig.local (like .zshrc.local)
+
 # --- Neovim ---
 link "$DOTFILES/.config/nvim/init.lua" "$HOME/.config/nvim/init.lua"
 

--- a/test-dotfiles.sh
+++ b/test-dotfiles.sh
@@ -131,6 +131,17 @@ check_link() {
 }
 check_link "$HOME/.tmux.conf" "$dotfiles_dir/.tmux.conf"
 check_link "$HOME/.config/nvim/init.lua" "$dotfiles_dir/.config/nvim/init.lua"
+# .gitconfig is not symlinked by install.sh (portability issues — see install.sh)
+if [ -L "$HOME/.gitconfig" ]; then
+    actual=$(readlink -f "$HOME/.gitconfig" 2>/dev/null || readlink "$HOME/.gitconfig")
+    if printf '%s' "$actual" | grep -q "dotfiles"; then
+        pass "$HOME/.gitconfig -> $actual"
+    else
+        warn "$HOME/.gitconfig -> $actual (not pointing to dotfiles)"
+    fi
+else
+    skip "$HOME/.gitconfig (not managed by install.sh)"
+fi
 # zshrc could be .zshrc or .zshrc.server depending on install mode
 if [ -L "$HOME/.zshrc" ]; then
     actual=$(readlink -f "$HOME/.zshrc" 2>/dev/null || readlink "$HOME/.zshrc")


### PR DESCRIPTION
### Changes

**1. `.zshrc.server`: Add missing `FZF_CTRL_T_COMMAND` and `FZF_ALT_C_COMMAND`**

The desktop `.zshrc` sets all three fzf env vars when fd is available, but `.zshrc.server` only set `FZF_DEFAULT_COMMAND`. This means Ctrl+T (file search) and Alt+C (cd to directory) fell back to the slow default `find` command on servers even when fd was installed.

Now uses the same `FD_CMD` variable pattern as the desktop config.

**2. `install.sh`: Add comment explaining why `.gitconfig` is not symlinked**

The README lists `.gitconfig` as included, and AGENTS.md documents the portability issues, but install.sh had no indication this was intentional. Added a comment block referencing the known issues (hardcoded gh path, delta dependency, LFS required=true) and the planned fix (base + .gitconfig.local split).

**3. `test-dotfiles.sh`: Add `.gitconfig` symlink check**

Test 5 (Symlinks) checked .tmux.conf, nvim/init.lua, and .zshrc but silently skipped .gitconfig. Now shows `SKIP: ~/.gitconfig (not managed by install.sh)` so it is visible in diagnostics. Will auto-upgrade to PASS if .gitconfig symlink is added later.

### Testing

- `zsh -n .zshrc.server` ✅
- Docker container: fzf vars empty without fd, all three populated after `apt install fd-find` ✅
- `test-dotfiles.sh` shows SKIP for .gitconfig, 0 failures ✅